### PR TITLE
cast memory variables to float before division

### DIFF
--- a/examples/sysinfo.py
+++ b/examples/sysinfo.py
@@ -31,8 +31,8 @@ def get_my_temp():
 
 
 def get_my_free_mem():
-    total_mem = int(run_cmd(TOTAL_MEM_CMD))
-    used_mem = int(run_cmd(USED_MEM_CMD))
+    total_mem = float(run_cmd(TOTAL_MEM_CMD))
+    used_mem = float(run_cmd(USED_MEM_CMD))
     mem_perc = used_mem / total_mem
     return "{:.1%}".format(mem_perc)
 


### PR DESCRIPTION
problem was I saw nothing but 0% on my raspberry, running python 2.7
this fixes that.
