### PR TITLE
Wrong queue class used in IREventListener

### DIFF
--- a/pifacecad/ir.py
+++ b/pifacecad/ir.py
@@ -36,7 +36,7 @@ class IREventListener(object):
         self.prog = prog
         self.lircrc = lircrc
         self.ir_function_maps = list()
-        self.event_queue = multiprocessing.queues.SimpleQueue()
+        self.event_queue = multiprocessing.SimpleQueue()
         self.detector = multiprocessing.Process(
             target=watch_ir_events, args=(self.event_queue,))
         self.dispatcher = threading.Thread(


### PR DESCRIPTION
When creating a new IR event listener
`irlistener = pifacecad.IREventListener(
        prog="pifacecad-radio-example",
        lircrc="/usr/share/doc/python3-pifacecad/examples/radiolircrc")`

it would fail with a message
`File "/usr/lib/python3/dist-packages/pifacecad/ir.py", line 39, in __init__
self.event_queue = multiprocessing.queues.SimpleQueue()
TypeError: __init__() missing 1 required keyword-only argument: 'ctx'`

Use multiprocessing.SimpleQueue instead of multiprocessing.queues.SimpleQueue in IREventListener. The latter seems to be a lower-level interface, which expects a context to be passed to it (which multiprocessing.SimpleQueue does pass). This was preventing a listener from being initialized in the radio example (note that ir was *not configured* anyway).

Understood the issue after seeing
http://bugs.python.org/issue21367

As per Python 3 docs it is
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.SimpleQueue