### PR TITLE
Instructions on how to build and install pifacecad on Raspbian Stretch/RaspberrPi 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,39 +41,41 @@ however, simply build them from their sources:
 
 * Enable the spi-interface:
 
+```
 	$ sudo raspi-config
 	Interfacing Options -> SPI -> Yes
-
+```
 * https://github.com/tompreston/python-lirc
+```
 	$ sudo aptitude install liblircclient-dev cython gcc python{,3}-setuptools python{,3}-dev
-
 	$ git clone https://github.com/tompreston/python-lirc.git
 	$ cd python-lirc/
 	$ make py3 && sudo python3 setup.py install
 	$ make py2 && sudo python setup.py install
-
+```
 * https://github.com/piface/pifacecommon
-
+```
 	$ git clone https://github.com/piface/pifacecommon.git
 	$ cd pifacecommon/
 	$ sudo python setup.py install
 	$ sudo python3 setup.py install
-
+```
 * https://github.com/piface/pifacecad
-
+```
 	$ git clone https://github.com/piface/pifacecad.git
 	$ cd pifacecad/
 	$ sudo python setup.py install
 	$ sudo python3 setup.py install
-
+```
 * run the hello world demo:
-
+```
 	>>> import pifacecad
 
 	>>> cad = pifacecad.PiFaceCAD()    # create PiFace Control and Display object
 	>>> cad.lcd.backlight_on()         # turns the backlight on
 	>>> cad.lcd.write("Hello, world!") # writes hello world on to the LCD
-
+```
 * Cleanup: 
-
+```
 	$ sudo rm -rf pifacecad/ pifacecommon/ python-lirc/
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can also find the documentation and some examples installed at:
 Install
 =======
 
-Make sure you are using the lastest version of Raspbian:
+Make sure you are using the latest version of Raspbian:
 
     $ sudo apt-get update
     $ sudo apt-get upgrade
@@ -32,3 +32,42 @@ Test by running the `sysinfo.py` program:
     $ python3 /usr/share/doc/python3-pifacecad/examples/sysinfo.py
 
 You will need to [configure the IR receiver](http://pifacecad.readthedocs.org/en/latest/lirc.html).
+
+Install on Raspbian Strech and RaspberryPi 3
+============================================
+
+The piface packages are currently not in the main repositories. You can,
+however, simply build them from their sources:
+
+* Enable the spi-interface:
+	$ sudo raspi-config
+	Interfacing Options -> SPI -> Yes
+
+* https://github.com/tompreston/python-lirc
+	$ sudo aptitude install liblircclient-dev cython gcc python{,3}-setuptools python{,3}-dev
+	$ git clone https://github.com/tompreston/python-lirc.git
+	$ cd python-lirc/
+	$ make py3 && sudo python3 setup.py install
+	$ make py2 && sudo python setup.py install
+
+* https://github.com/piface/pifacecommon
+	$ git clone https://github.com/piface/pifacecommon.git
+	$ cd pifacecommon/
+	$ sudo python setup.py install
+	$ sudo python3 setup.py install
+
+* https://github.com/piface/pifacecad
+	$ git clone https://github.com/piface/pifacecad.git
+	$ cd pifacecad/
+	$ sudo python setup.py install
+	$ sudo python3 setup.py install
+
+* run the hello world demo:
+	>>> import pifacecad
+
+	>>> cad = pifacecad.PiFaceCAD()    # create PiFace Control and Display object
+	>>> cad.lcd.backlight_on()         # turns the backlight on
+	>>> cad.lcd.write("Hello, world!") # writes hello world on to the LCD
+
+* Cleanup: 
+	$ sudo rm -rf pifacecad/ pifacecommon/ python-lirc/

--- a/README.md
+++ b/README.md
@@ -40,29 +40,34 @@ The piface packages are currently not in the main repositories. You can,
 however, simply build them from their sources:
 
 * Enable the spi-interface:
+
 	$ sudo raspi-config
 	Interfacing Options -> SPI -> Yes
 
 * https://github.com/tompreston/python-lirc
 	$ sudo aptitude install liblircclient-dev cython gcc python{,3}-setuptools python{,3}-dev
+
 	$ git clone https://github.com/tompreston/python-lirc.git
 	$ cd python-lirc/
 	$ make py3 && sudo python3 setup.py install
 	$ make py2 && sudo python setup.py install
 
 * https://github.com/piface/pifacecommon
+
 	$ git clone https://github.com/piface/pifacecommon.git
 	$ cd pifacecommon/
 	$ sudo python setup.py install
 	$ sudo python3 setup.py install
 
 * https://github.com/piface/pifacecad
+
 	$ git clone https://github.com/piface/pifacecad.git
 	$ cd pifacecad/
 	$ sudo python setup.py install
 	$ sudo python3 setup.py install
 
 * run the hello world demo:
+
 	>>> import pifacecad
 
 	>>> cad = pifacecad.PiFaceCAD()    # create PiFace Control and Display object
@@ -70,4 +75,5 @@ however, simply build them from their sources:
 	>>> cad.lcd.write("Hello, world!") # writes hello world on to the LCD
 
 * Cleanup: 
+
 	$ sudo rm -rf pifacecad/ pifacecommon/ python-lirc/


### PR DESCRIPTION
Hello,

apparently the piface packages are currently not in the Raspbian repositories. According one issues this situation might last for some time. Since it is very easy to install pifacecad from its sources, it might be useful for some users to find the installation instructions in the repository.

I extended the README.txt with the (tested) instructions. They work for me on the lastest version of Raspbian and a RaspberryPi 3.

Cheers,
Severin